### PR TITLE
Safeguard the last '\' to enable copy from drive root

### DIFF
--- a/ChoAppSettings.cs
+++ b/ChoAppSettings.cs
@@ -1003,19 +1003,27 @@
             return "{0} {1}".FormatString(RoboCopyFilePath, GetCmdLineParams());
         }
 
+        string DirSafeguard(string path)
+        {
+            // Escape the last '\' from the path if it is not escaped yet.
+            if (path.Last() == '\\' && (path[path.Length - 2] != '\\'))
+                path += '\\';
+            return path;
+        }
+
         internal string GetCmdLineParams(string sourceDirectory = null, string destDirectory = null)
         {
             StringBuilder cmdText = new StringBuilder();
             
             if (!sourceDirectory.IsNullOrWhiteSpace())
-                cmdText.AppendFormat(" \"{0}\"", sourceDirectory);
+                cmdText.AppendFormat(" \"{0}\"", DirSafeguard(sourceDirectory));
             else if (!SourceDirectory.IsNullOrWhiteSpace())
-                cmdText.AppendFormat(" \"{0}\"", SourceDirectory);
+                cmdText.AppendFormat(" \"{0}\"", DirSafeguard(SourceDirectory));
 
             if (!destDirectory.IsNullOrWhiteSpace())
-                cmdText.AppendFormat(" \"{0}\"", destDirectory);
+                cmdText.AppendFormat(" \"{0}\"", DirSafeguard(destDirectory));
             else if (!DestDirectory.IsNullOrWhiteSpace())
-                cmdText.AppendFormat(" \"{0}\"", DestDirectory);
+                cmdText.AppendFormat(" \"{0}\"", DirSafeguard(DestDirectory));
 
             if (!Files.IsNullOrWhiteSpace())
                 cmdText.AppendFormat(" {0}", Files);


### PR DESCRIPTION
As reported in issue #2 , Windows cmd tends to translate the last '\' into escape character, which results to an invalid parameter error.

This patch adds another slash to escape the intended slash.

Current Cho version:
```
C:\Windows\system32>RoboCopy.exe  "C:\" "E:\tmpzone" *.* /E /MT:8

-------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : 2018/2/2 10:56:41
   Source -
     Dest -

    Files :
  Options : /DCOPY:DA /COPY:DAT /R:1000000 /W:30

------------------------------------------------------------------------------

ERROR : Invalid Parameter #1 : "C:" E:\tmpzone *.* /E /MT:8"
(abridged)
```

After my escape patch:
```
C:\Windows\system32>RoboCopy.exe  "C:\\" "E:\tmpzone" *.* /E /MT:8

-------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : 2018/2/2 10:57:34
   Source : C:\
     Dest : E:\tmpzone\

    Files : *.*

  Options : *.* /S /E /DCOPY:DA /COPY:DAT /MT:8 /R:1000000 /W:30

------------------------------------------------------------------------------

100%        New File              384322        C:\bootmgr
100%        New File                   1        C:\BOOTNXT
            New File               3.1 g        C:\hiberfil.sys
2018/02/02 10:57:37 ERROR 32 (0x00000020) Copying File C:\hiberfil.sys
The process cannot access the file because it is being used by another process.

            New File               2.1 g        C:\pagefile.sys
2018/02/02 10:57:37 ERROR 32 (0x00000020) Copying File C:\pagefile.sys
The process cannot access the file because it is being used by another process.
(abridged)
```